### PR TITLE
Add p2p failed event

### DIFF
--- a/Runtime/NativeClientState.cs
+++ b/Runtime/NativeClientState.cs
@@ -15,14 +15,13 @@ namespace Extreal.Integration.P2P.WebRTC
 
         private readonly Subject<bool> isIceCandidateGatheringFinished = new Subject<bool>();
         private readonly Subject<bool> isOfferAnswerProcessFinished = new Subject<bool>();
-        private readonly Subject<bool> isHostConnected = new Subject<bool>();
 
         [SuppressMessage("CodeCracker", "CC0092")]
         internal NativeClientState()
         {
             isIceCandidateGatheringFinished.AddTo(disposables);
             isOfferAnswerProcessFinished.AddTo(disposables);
-            Observable.CombineLatest(isIceCandidateGatheringFinished, isOfferAnswerProcessFinished, isHostConnected)
+            Observable.CombineLatest(isIceCandidateGatheringFinished, isOfferAnswerProcessFinished)
                 .Where(readies => readies.All(ready => ready))
                 .Subscribe(_ => onStarted.OnNext(Unit.Default))
                 .AddTo(disposables);
@@ -30,13 +29,11 @@ namespace Extreal.Integration.P2P.WebRTC
 
         internal void FinishIceCandidateGathering() => isIceCandidateGatheringFinished.OnNext(true);
         internal void FinishOfferAnswerProcess() => isOfferAnswerProcessFinished.OnNext(true);
-        internal void FinishHostConnection(bool isConnectionWithHost) => isHostConnected.OnNext(isConnectionWithHost);
 
         internal void Clear()
         {
             isIceCandidateGatheringFinished.OnNext(false);
             isOfferAnswerProcessFinished.OnNext(false);
-            isHostConnected.OnNext(false);
         }
 
         protected override void ReleaseManagedResources() => disposables.Dispose();

--- a/Runtime/NativeClientState.cs
+++ b/Runtime/NativeClientState.cs
@@ -15,13 +15,14 @@ namespace Extreal.Integration.P2P.WebRTC
 
         private readonly Subject<bool> isIceCandidateGatheringFinished = new Subject<bool>();
         private readonly Subject<bool> isOfferAnswerProcessFinished = new Subject<bool>();
+        private readonly Subject<bool> isHostConnected = new Subject<bool>();
 
         [SuppressMessage("CodeCracker", "CC0092")]
         internal NativeClientState()
         {
             isIceCandidateGatheringFinished.AddTo(disposables);
             isOfferAnswerProcessFinished.AddTo(disposables);
-            Observable.CombineLatest(isIceCandidateGatheringFinished, isOfferAnswerProcessFinished)
+            Observable.CombineLatest(isIceCandidateGatheringFinished, isOfferAnswerProcessFinished, isHostConnected)
                 .Where(readies => readies.All(ready => ready))
                 .Subscribe(_ => onStarted.OnNext(Unit.Default))
                 .AddTo(disposables);
@@ -29,11 +30,13 @@ namespace Extreal.Integration.P2P.WebRTC
 
         internal void FinishIceCandidateGathering() => isIceCandidateGatheringFinished.OnNext(true);
         internal void FinishOfferAnswerProcess() => isOfferAnswerProcessFinished.OnNext(true);
+        internal void FinishHostConnection(bool isConnectionWithHost) => isHostConnected.OnNext(isConnectionWithHost);
 
         internal void Clear()
         {
             isIceCandidateGatheringFinished.OnNext(false);
             isOfferAnswerProcessFinished.OnNext(false);
+            isHostConnected.OnNext(false);
         }
 
         protected override void ReleaseManagedResources() => disposables.Dispose();

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -109,7 +109,7 @@ namespace Extreal.Integration.P2P.WebRTC
             }
             catch (ConnectionException e)
             {
-                FireOnConnectFailed(e.Message);
+                FireOnSignalingConnectFailed(e.Message);
                 throw;
             }
 
@@ -205,7 +205,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 Logger.LogDebug($"{nameof(ReceiveDisconnectedAsync)}: {reason}");
             }
             await UniTask.SwitchToMainThread();
-            FireOnDisconnected(reason);
+            FireOnSignalingDisconnected(reason);
         }
 
         protected override async UniTask<StartHostResponse> DoStartHostAsync(string name)

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -356,23 +356,14 @@ namespace Extreal.Integration.P2P.WebRTC
                         break;
                     }
                     case RTCIceConnectionState.Connected:
-                        if (Role == PeerRole.Client)
-                        {
-                            clientState.FinishHostConnection(HostId == id);
-
-                        }
-                        else
-                        {
-                            clientState.FinishHostConnection(true);
-                        }
-
-                        break;
                     case RTCIceConnectionState.Completed:
                     {
                         if (Role == PeerRole.Client)
                         {
                             clientState.FinishIceCandidateGathering();
+                            clientState.FinishHostConnection(HostId == id);
                         }
+                        clientState.FinishHostConnection(true);
                         break;
                     }
                     case RTCIceConnectionState.Failed:

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -343,13 +343,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 {
                     case RTCIceConnectionState.New:
                     case RTCIceConnectionState.Checking:
-                        break;
                     case RTCIceConnectionState.Disconnected:
-                        if (Role == PeerRole.Client)
-                        {
-                            FireOnStartedFailed();
-                        }
-                        break;
                     case RTCIceConnectionState.Max:
                     {
                         // do nothing
@@ -361,17 +355,10 @@ namespace Extreal.Integration.P2P.WebRTC
                         if (Role == PeerRole.Client)
                         {
                             clientState.FinishIceCandidateGathering();
-                            clientState.FinishHostConnection(HostId == id);
                         }
-                        clientState.FinishHostConnection(true);
                         break;
                     }
                     case RTCIceConnectionState.Failed:
-                        if (Role == PeerRole.Client)
-                        {
-                            FireOnStartedFailed();
-                        }
-                        break;
                     case RTCIceConnectionState.Closed:
                     {
                         // Not covered by testing due to defensive implementation

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -343,6 +343,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 {
                     case RTCIceConnectionState.New:
                     case RTCIceConnectionState.Checking:
+                        break;
                     case RTCIceConnectionState.Disconnected:
                         if (Role == PeerRole.Client)
                         {
@@ -360,7 +361,11 @@ namespace Extreal.Integration.P2P.WebRTC
                             clientState.FinishHostConnection(HostId == id);
 
                         }
-                        clientState.FinishHostConnection(true);
+                        else
+                        {
+                            clientState.FinishHostConnection(true);
+                        }
+
                         break;
                     case RTCIceConnectionState.Completed:
                     {

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -355,6 +355,13 @@ namespace Extreal.Integration.P2P.WebRTC
                         break;
                     }
                     case RTCIceConnectionState.Connected:
+                        if (Role == PeerRole.Client)
+                        {
+                            clientState.FinishHostConnection(HostId == id);
+
+                        }
+                        clientState.FinishHostConnection(true);
+                        break;
                     case RTCIceConnectionState.Completed:
                     {
                         if (Role == PeerRole.Client)

--- a/Runtime/NativePeerClient.cs
+++ b/Runtime/NativePeerClient.cs
@@ -344,6 +344,11 @@ namespace Extreal.Integration.P2P.WebRTC
                     case RTCIceConnectionState.New:
                     case RTCIceConnectionState.Checking:
                     case RTCIceConnectionState.Disconnected:
+                        if (Role == PeerRole.Client)
+                        {
+                            FireOnStartedFailed();
+                        }
+                        break;
                     case RTCIceConnectionState.Max:
                     {
                         // do nothing
@@ -359,6 +364,11 @@ namespace Extreal.Integration.P2P.WebRTC
                         break;
                     }
                     case RTCIceConnectionState.Failed:
+                        if (Role == PeerRole.Client)
+                        {
+                            FireOnStartedFailed();
+                        }
+                        break;
                     case RTCIceConnectionState.Closed:
                     {
                         // Not covered by testing due to defensive implementation

--- a/Runtime/PeerClient.cs
+++ b/Runtime/PeerClient.cs
@@ -72,7 +72,7 @@ namespace Extreal.Integration.P2P.WebRTC
         /// </summary>
         protected void FireOnStartedFailed()
         {
-            if (!IsRunning)
+            if (IsRunning)
             {
                 // Not covered by testing due to defensive implementation
                 return;

--- a/Runtime/PeerClient.cs
+++ b/Runtime/PeerClient.cs
@@ -22,6 +22,12 @@ namespace Extreal.Integration.P2P.WebRTC
         private readonly Subject<Unit> onStarted = new Subject<Unit>();
 
         /// <summary>
+        /// Invokes immediately after the host or client starts failed.
+        /// </summary>
+        public IObservable<Unit> OnStartedFailed => onStartedFailed.AddTo(Disposables);
+        private readonly Subject<Unit> onStartedFailed = new Subject<Unit>();
+
+        /// <summary>
         /// Invokes immediately after the host or client has failed to connect to the signaling server.
         /// </summary>
         public IObservable<string> OnConnectFailed => onConnectFailed.AddTo(Disposables);
@@ -59,6 +65,24 @@ namespace Extreal.Integration.P2P.WebRTC
             }
             IsRunning = true;
             onStarted.OnNext(Unit.Default);
+        }
+
+        /// <summary>
+        /// Fires the OnStartedFailed.
+        /// </summary>
+        protected void FireOnStartedFailed()
+        {
+            if (!IsRunning)
+            {
+                // Not covered by testing due to defensive implementation
+                return;
+            }
+            if (Logger.IsDebug())
+            {
+                Logger.LogDebug("P2P started failed");
+            }
+            IsRunning = false;
+            onStartedFailed.OnNext(Unit.Default);
         }
 
         /// <summary>

--- a/Runtime/PeerClient.cs
+++ b/Runtime/PeerClient.cs
@@ -22,12 +22,6 @@ namespace Extreal.Integration.P2P.WebRTC
         private readonly Subject<Unit> onStarted = new Subject<Unit>();
 
         /// <summary>
-        /// Invokes immediately after the host or client starts failed.
-        /// </summary>
-        public IObservable<Unit> OnStartedFailed => onStartedFailed.AddTo(Disposables);
-        private readonly Subject<Unit> onStartedFailed = new Subject<Unit>();
-
-        /// <summary>
         /// Invokes immediately after the host or client has failed to connect to the signaling server.
         /// </summary>
         public IObservable<string> OnConnectFailed => onConnectFailed.AddTo(Disposables);
@@ -65,24 +59,6 @@ namespace Extreal.Integration.P2P.WebRTC
             }
             IsRunning = true;
             onStarted.OnNext(Unit.Default);
-        }
-
-        /// <summary>
-        /// Fires the OnStartedFailed.
-        /// </summary>
-        protected void FireOnStartedFailed()
-        {
-            if (IsRunning)
-            {
-                // Not covered by testing due to defensive implementation
-                return;
-            }
-            if (Logger.IsDebug())
-            {
-                Logger.LogDebug("P2P started failed");
-            }
-            IsRunning = false;
-            onStartedFailed.OnNext(Unit.Default);
         }
 
         /// <summary>

--- a/Runtime/PeerClient.cs
+++ b/Runtime/PeerClient.cs
@@ -22,6 +22,12 @@ namespace Extreal.Integration.P2P.WebRTC
         private readonly Subject<Unit> onStarted = new Subject<Unit>();
 
         /// <summary>
+        /// Invokes immediately after the host or client starts failed.
+        /// </summary>
+        public IObservable<Unit> OnStartedFailed => onStartedFailed.AddTo(Disposables);
+        private readonly Subject<Unit> onStartedFailed = new Subject<Unit>();
+
+        /// <summary>
         /// Invokes immediately after the host or client has failed to connect to the signaling server.
         /// </summary>
         public IObservable<string> OnConnectFailed => onConnectFailed.AddTo(Disposables);
@@ -59,6 +65,24 @@ namespace Extreal.Integration.P2P.WebRTC
             }
             IsRunning = true;
             onStarted.OnNext(Unit.Default);
+        }
+
+        /// <summary>
+        /// Fires the OnStartedFailed.
+        /// </summary>
+        protected void FireOnStartedFailed()
+        {
+            if (IsRunning)
+            {
+                // Not covered by testing due to defensive implementation
+                return;
+            }
+            if (Logger.IsDebug())
+            {
+                Logger.LogDebug("P2P started failed");
+            }
+            IsRunning = false;
+            onStartedFailed.OnNext(Unit.Default);
         }
 
         /// <summary>

--- a/Runtime/PeerClient.cs
+++ b/Runtime/PeerClient.cs
@@ -22,22 +22,22 @@ namespace Extreal.Integration.P2P.WebRTC
         private readonly Subject<Unit> onStarted = new Subject<Unit>();
 
         /// <summary>
-        /// Invokes immediately after the host or client starts failed.
+        /// Invokes immediately after the host or client has failed to start.
         /// </summary>
-        public IObservable<Unit> OnStartedFailed => onStartedFailed.AddTo(Disposables);
-        private readonly Subject<Unit> onStartedFailed = new Subject<Unit>();
+        public IObservable<Unit> OnStartFailed => onStartFailed.AddTo(Disposables);
+        private readonly Subject<Unit> onStartFailed = new Subject<Unit>();
 
         /// <summary>
         /// Invokes immediately after the host or client has failed to connect to the signaling server.
         /// </summary>
-        public IObservable<string> OnConnectFailed => onConnectFailed.AddTo(Disposables);
-        private readonly Subject<string> onConnectFailed = new Subject<string>();
+        public IObservable<string> OnSignalingConnectFailed => onSignalingConnectFailed.AddTo(Disposables);
+        private readonly Subject<string> onSignalingConnectFailed = new Subject<string>();
 
         /// <summary>
         /// Invokes immediately after a host or client connected to the signaling server is disconnected.
         /// </summary>
-        public IObservable<string> OnDisconnected => onDisconnected.AddTo(Disposables);
-        private readonly Subject<string> onDisconnected = new Subject<string>();
+        public IObservable<string> OnSignalingDisconnected => onSignalingDisconnected.AddTo(Disposables);
+        private readonly Subject<string> onSignalingDisconnected = new Subject<string>();
 
         /// <summary>
         /// Whether it is running or not.
@@ -68,9 +68,9 @@ namespace Extreal.Integration.P2P.WebRTC
         }
 
         /// <summary>
-        /// Fires the OnStartedFailed.
+        /// Fires the OnStartFailed.
         /// </summary>
-        protected void FireOnStartedFailed()
+        protected void FireOnStartFailed()
         {
             if (IsRunning)
             {
@@ -82,38 +82,38 @@ namespace Extreal.Integration.P2P.WebRTC
                 Logger.LogDebug("P2P started failed");
             }
             IsRunning = false;
-            onStartedFailed.OnNext(Unit.Default);
+            onStartFailed.OnNext(Unit.Default);
         }
 
         /// <summary>
-        /// Fires the OnConnectFailed.
+        /// Fires the OnSignalingConnectFailed.
         /// </summary>
         /// <param name="reason">Reason</param>
-        protected void FireOnConnectFailed(string reason)
+        protected void FireOnSignalingConnectFailed(string reason)
         {
             if (Logger.IsDebug())
             {
-                Logger.LogDebug($"{nameof(FireOnConnectFailed)}: reason={reason}");
+                Logger.LogDebug($"{nameof(FireOnSignalingConnectFailed)}: reason={reason}");
             }
-            onConnectFailed.OnNext(reason);
+            onSignalingConnectFailed.OnNext(reason);
         }
 
         /// <summary>
-        /// Fires the OnDisconnected.
+        /// Fires the OnSignalingDisconnected.
         /// </summary>
         /// <param name="reason">Reason</param>
-        protected void FireOnDisconnected(string reason)
+        protected void FireOnSignalingDisconnected(string reason)
         {
             if (Logger.IsDebug())
             {
-                Logger.LogDebug($"{nameof(FireOnDisconnected)}: reason={reason}");
+                Logger.LogDebug($"{nameof(FireOnSignalingDisconnected)}: reason={reason}");
             }
             if (reason == "io client disconnect")
             {
                 // Not covered by testing due to defensive implementation
                 return;
             }
-            onDisconnected.OnNext(reason);
+            onSignalingDisconnected.OnNext(reason);
         }
 
         /// <inheritdoc/>

--- a/Runtime/PeerClientProvider.cs
+++ b/Runtime/PeerClientProvider.cs
@@ -16,13 +16,12 @@ namespace Extreal.Integration.P2P.WebRTC
         /// <param name="peerConfig">Peer configuration</param>
         /// <returns>PeerClient</returns>
         [SuppressMessage("Style", "CC0038")]
-        public static PeerClient Provide(PeerConfig peerConfig)
-        {
+        public static PeerClient Provide(PeerConfig peerConfig) =>
 #if !UNITY_WEBGL || UNITY_EDITOR
-            return new NativePeerClient(peerConfig);
+            new NativePeerClient(peerConfig);
 #else
-            return new WebGLPeerClient(new WebGLPeerConfig(peerConfig));
+            new WebGLPeerClient(new WebGLPeerConfig(peerConfig));
 #endif
-        }
+
     }
 }

--- a/Runtime/PeerConfig.cs
+++ b/Runtime/PeerConfig.cs
@@ -14,6 +14,11 @@ namespace Extreal.Integration.P2P.WebRTC
         public string SignalingUrl { get; }
 
         /// <summary>
+        /// Timeout value in seconds for the P2P negotiation process.
+        /// </summary>
+        public int NegotiationTimeoutSeconds { get; }
+
+        /// <summary>
         /// Socket options.
         /// </summary>
         public SocketIOOptions SocketOptions { get; }
@@ -29,9 +34,10 @@ namespace Extreal.Integration.P2P.WebRTC
         /// <param name="url">URL of the signaling server</param>
         /// <param name="socketOptions">Socket options</param>
         /// <param name="iceServerUrls">Ice server URLs</param>
-        public PeerConfig(string url, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null)
+        public PeerConfig(string url, int negotiationTimeoutSeconds, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null)
         {
             SignalingUrl = url;
+            NegotiationTimeoutSeconds = negotiationTimeoutSeconds;
             SocketOptions = socketOptions ?? new SocketIOOptions();
             IceServerUrls = iceServerUrls ?? new List<string>();
         }

--- a/Runtime/PeerConfig.cs
+++ b/Runtime/PeerConfig.cs
@@ -32,6 +32,7 @@ namespace Extreal.Integration.P2P.WebRTC
         /// Creates a new peer configuration.
         /// </summary>
         /// <param name="url">URL of the signaling server</param>
+        /// <param name="NegotiationTimeoutSeconds">Timeout value in seconds for the P2P negotiation process.</param>
         /// <param name="socketOptions">Socket options</param>
         /// <param name="iceServerUrls">Ice server URLs</param>
         public PeerConfig(string url, int negotiationTimeoutSeconds, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null)

--- a/Runtime/PeerConfig.cs
+++ b/Runtime/PeerConfig.cs
@@ -32,7 +32,7 @@ namespace Extreal.Integration.P2P.WebRTC
         /// Creates a new peer configuration.
         /// </summary>
         /// <param name="url">URL of the signaling server</param>
-        /// <param name="NegotiationTimeoutSeconds">Timeout value in seconds for the P2P negotiation process.</param>
+        /// <param name="negotiationTimeoutSeconds">Timeout value in seconds for the P2P negotiation process.</param>
         /// <param name="socketOptions">Socket options</param>
         /// <param name="iceServerUrls">Ice server URLs</param>
         public PeerConfig(string url, int negotiationTimeoutSeconds, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null)

--- a/Runtime/PeerConfig.cs
+++ b/Runtime/PeerConfig.cs
@@ -37,7 +37,7 @@ namespace Extreal.Integration.P2P.WebRTC
         /// <param name="iceServerUrls">Ice server URLs</param>
         /// <param name="timeout">
         /// <para>Time to wait when P2P starting is not successful</para>
-        /// Default: 10 seconds
+        /// Default: 15 seconds
         /// </param>
         public PeerConfig(string url, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null, TimeSpan timeout = default)
         {

--- a/Runtime/PeerConfig.cs
+++ b/Runtime/PeerConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SocketIOClient;
 
 namespace Extreal.Integration.P2P.WebRTC
@@ -14,9 +15,9 @@ namespace Extreal.Integration.P2P.WebRTC
         public string SignalingUrl { get; }
 
         /// <summary>
-        /// Timeout value in seconds for the P2P negotiation process.
+        /// Time to wait when P2P starting is not successful.
         /// </summary>
-        public int NegotiationTimeoutSeconds { get; }
+        public TimeSpan Timeout { get; }
 
         /// <summary>
         /// Socket options.
@@ -32,15 +33,18 @@ namespace Extreal.Integration.P2P.WebRTC
         /// Creates a new peer configuration.
         /// </summary>
         /// <param name="url">URL of the signaling server</param>
-        /// <param name="negotiationTimeoutSeconds">Timeout value in seconds for the P2P negotiation process.</param>
         /// <param name="socketOptions">Socket options</param>
         /// <param name="iceServerUrls">Ice server URLs</param>
-        public PeerConfig(string url, int negotiationTimeoutSeconds, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null)
+        /// <param name="timeout">
+        /// <para>Time to wait when P2P starting is not successful</para>
+        /// Default: 10 seconds
+        /// </param>
+        public PeerConfig(string url, SocketIOOptions socketOptions = null, List<string> iceServerUrls = null, TimeSpan timeout = default)
         {
             SignalingUrl = url;
-            NegotiationTimeoutSeconds = negotiationTimeoutSeconds;
             SocketOptions = socketOptions ?? new SocketIOOptions();
             IceServerUrls = iceServerUrls ?? new List<string>();
+            Timeout = timeout == default ? TimeSpan.FromSeconds(15) : timeout;
         }
     }
 }

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -103,7 +103,7 @@ namespace Extreal.Integration.P2P.WebRTC
             var socketOptions = peerConfig.SocketOptions;
             var jsonSocketOptions = new JsonSocketOptions
             {
-                ConnectionTimeout = socketOptions.ConnectionTimeout.TotalSeconds,
+                ConnectionTimeout = (int)socketOptions.ConnectionTimeout.TotalMilliseconds,
                 Reconnection = socketOptions.Reconnection,
             };
             var jsonPeerConfig = new JsonPeerConfig
@@ -111,7 +111,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 Url = peerConfig.SignalingUrl,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
-                Timeout = peerConfig.Timeout.TotalSeconds,
+                Timeout = (int)peerConfig.Timeout.TotalMilliseconds,
                 IsDebug = peerConfig.IsDebug
             };
             return JsonSerializer.Serialize(jsonPeerConfig);

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -109,6 +109,7 @@ namespace Extreal.Integration.P2P.WebRTC
             var jsonPeerConfig = new JsonPeerConfig
             {
                 Url = peerConfig.SignalingUrl,
+                NegotiationTimeoutSeconds = peerConfig.NegotiationTimeoutSeconds,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
                 IsDebug = peerConfig.IsDebug
@@ -122,6 +123,9 @@ namespace Extreal.Integration.P2P.WebRTC
     {
         [JsonPropertyName("url")]
         public string Url { get; set; }
+
+        [JsonPropertyName("negotiationTimeoutSeconds")]
+        public int NegotiationTimeoutSeconds { get; set; }
 
         [JsonPropertyName("socketOptions")]
         public JsonSocketOptions SocketOptions { get; set; }

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -111,7 +111,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 Url = peerConfig.SignalingUrl,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
-                Timeout = peerConfig.timeout,
+                Timeout = peerConfig.Timeout,
                 IsDebug = peerConfig.IsDebug
             };
             return JsonSerializer.Serialize(jsonPeerConfig);

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -24,6 +24,7 @@ namespace Extreal.Integration.P2P.WebRTC
             cancellation = new CancellationTokenSource();
             WebGLHelper.CallAction(WithPrefix(nameof(WebGLPeerClient)), ToJson(peerConfig));
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStarted)), HandleOnStarted);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStartedFailed)), HandleOnStartedFailed);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnConnectFailed)), HandleOnConnectFailed);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnDisconnected)), HandleOnDisconnected);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveStartHostResponse)), ReceiveStartHostResponse);
@@ -32,6 +33,9 @@ namespace Extreal.Integration.P2P.WebRTC
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void HandleOnStarted(string unused1, string unused2) => instance.FireOnStarted();
+
+        [MonoPInvokeCallback(typeof(Action<string, string>))]
+        private static void HandleOnStartedFailed(string unused1, string unused2) => instance.FireOnStartedFailed();
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void HandleOnConnectFailed(string reason, string unused2) =>

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -103,7 +103,7 @@ namespace Extreal.Integration.P2P.WebRTC
             var socketOptions = peerConfig.SocketOptions;
             var jsonSocketOptions = new JsonSocketOptions
             {
-                ConnectionTimeout = socketOptions.ConnectionTimeout.Milliseconds,
+                ConnectionTimeout = socketOptions.ConnectionTimeout.TotalSeconds,
                 Reconnection = socketOptions.Reconnection,
             };
             var jsonPeerConfig = new JsonPeerConfig
@@ -111,7 +111,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 Url = peerConfig.SignalingUrl,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
-                Timeout = peerConfig.Timeout.Milliseconds,
+                Timeout = peerConfig.Timeout.TotalSeconds,
                 IsDebug = peerConfig.IsDebug
             };
             return JsonSerializer.Serialize(jsonPeerConfig);

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -24,9 +24,9 @@ namespace Extreal.Integration.P2P.WebRTC
             cancellation = new CancellationTokenSource();
             WebGLHelper.CallAction(WithPrefix(nameof(WebGLPeerClient)), ToJson(peerConfig));
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStarted)), HandleOnStarted);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStartedFailed)), HandleOnStartedFailed);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnConnectFailed)), HandleOnConnectFailed);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnDisconnected)), HandleOnDisconnected);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStartFailed)), HandleOnStartFailed);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleSignalingOnConnectFailed)), HandleSignalingOnConnectFailed);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleSignalingOnDisconnected)), HandleSignalingOnDisconnected);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveStartHostResponse)), ReceiveStartHostResponse);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveListHostsResponse)), ReceiveListHostsResponse);
         }
@@ -35,14 +35,14 @@ namespace Extreal.Integration.P2P.WebRTC
         private static void HandleOnStarted(string unused1, string unused2) => instance.FireOnStarted();
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleOnStartedFailed(string unused1, string unused2) => instance.FireOnStartedFailed();
+        private static void HandleOnStartFailed(string unused1, string unused2) => instance.FireOnStartFailed();
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleOnConnectFailed(string reason, string unused2) =>
-            instance.FireOnConnectFailed(reason);
+        private static void HandleSignalingOnConnectFailed(string reason, string unused2) =>
+            instance.FireOnSignalingConnectFailed(reason);
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleOnDisconnected(string reason, string unused2) => instance.FireOnDisconnected(reason);
+        private static void HandleSignalingOnDisconnected(string reason, string unused2) => instance.FireOnSignalingDisconnected(reason);
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void ReceiveStartHostResponse(string jsonResponse, string unused)
@@ -109,9 +109,9 @@ namespace Extreal.Integration.P2P.WebRTC
             var jsonPeerConfig = new JsonPeerConfig
             {
                 Url = peerConfig.SignalingUrl,
-                NegotiationTimeoutSeconds = peerConfig.NegotiationTimeoutSeconds,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
+                Timeout = peerConfig.timeout,
                 IsDebug = peerConfig.IsDebug
             };
             return JsonSerializer.Serialize(jsonPeerConfig);
@@ -124,8 +124,8 @@ namespace Extreal.Integration.P2P.WebRTC
         [JsonPropertyName("url")]
         public string Url { get; set; }
 
-        [JsonPropertyName("negotiationTimeoutSeconds")]
-        public int NegotiationTimeoutSeconds { get; set; }
+        [JsonPropertyName("timeout")]
+        public TimeSpan Timeout { get; set; }
 
         [JsonPropertyName("socketOptions")]
         public JsonSocketOptions SocketOptions { get; set; }

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -25,8 +25,8 @@ namespace Extreal.Integration.P2P.WebRTC
             WebGLHelper.CallAction(WithPrefix(nameof(WebGLPeerClient)), ToJson(peerConfig));
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStarted)), HandleOnStarted);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnStartFailed)), HandleOnStartFailed);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleSignalingOnConnectFailed)), HandleSignalingOnConnectFailed);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleSignalingOnDisconnected)), HandleSignalingOnDisconnected);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnSignalingConnectFailed)), HandleOnSignalingConnectFailed);
+            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnSignalingDisconnected)), HandleOnSignalingDisconnected);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveStartHostResponse)), ReceiveStartHostResponse);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveListHostsResponse)), ReceiveListHostsResponse);
         }
@@ -38,11 +38,11 @@ namespace Extreal.Integration.P2P.WebRTC
         private static void HandleOnStartFailed(string unused1, string unused2) => instance.FireOnStartFailed();
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleSignalingOnConnectFailed(string reason, string unused2) =>
+        private static void HandleOnSignalingConnectFailed(string reason, string unused2) =>
             instance.FireOnSignalingConnectFailed(reason);
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleSignalingOnDisconnected(string reason, string unused2) => instance.FireOnSignalingDisconnected(reason);
+        private static void HandleOnSignalingDisconnected(string reason, string unused2) => instance.FireOnSignalingDisconnected(reason);
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void ReceiveStartHostResponse(string jsonResponse, string unused)

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -111,7 +111,7 @@ namespace Extreal.Integration.P2P.WebRTC
                 Url = peerConfig.SignalingUrl,
                 SocketOptions = jsonSocketOptions,
                 PcConfig = jsonRtcConfiguration,
-                Timeout = peerConfig.Timeout,
+                Timeout = peerConfig.Timeout.Milliseconds,
                 IsDebug = peerConfig.IsDebug
             };
             return JsonSerializer.Serialize(jsonPeerConfig);
@@ -125,7 +125,7 @@ namespace Extreal.Integration.P2P.WebRTC
         public string Url { get; set; }
 
         [JsonPropertyName("timeout")]
-        public TimeSpan Timeout { get; set; }
+        public int Timeout { get; set; }
 
         [JsonPropertyName("socketOptions")]
         public JsonSocketOptions SocketOptions { get; set; }

--- a/Runtime/WebGLPeerConfig.cs
+++ b/Runtime/WebGLPeerConfig.cs
@@ -7,7 +7,7 @@ namespace Extreal.Integration.P2P.WebRTC
         private static readonly ELogger Logger = LoggingManager.GetLogger(nameof(WebGLPeerConfig));
 
         public WebGLPeerConfig(PeerConfig peerConfig)
-            : base(peerConfig.SignalingUrl, peerConfig.SocketOptions, peerConfig.IceServerUrls)
+            : base(peerConfig.SignalingUrl, peerConfig.NegotiationTimeoutSeconds, peerConfig.SocketOptions, peerConfig.IceServerUrls)
         {
         }
 

--- a/Runtime/WebGLPeerConfig.cs
+++ b/Runtime/WebGLPeerConfig.cs
@@ -7,7 +7,7 @@ namespace Extreal.Integration.P2P.WebRTC
         private static readonly ELogger Logger = LoggingManager.GetLogger(nameof(WebGLPeerConfig));
 
         public WebGLPeerConfig(PeerConfig peerConfig)
-            : base(peerConfig.SignalingUrl, peerConfig.NegotiationTimeoutSeconds, peerConfig.SocketOptions, peerConfig.IceServerUrls)
+            : base(peerConfig.SignalingUrl, peerConfig.SocketOptions, peerConfig.IceServerUrls, peerConfig.Timeout)
         {
         }
 

--- a/Samples~/MVS/ClientControl/ClientControlPresenter.cs
+++ b/Samples~/MVS/ClientControl/ClientControlPresenter.cs
@@ -26,6 +26,10 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
                 .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnStarted)}"))
                 .AddTo(disposables);
 
+            peerClient.OnStartedFailed
+                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnStartedFailed)}"))
+                .AddTo(disposables);
+
             peerClient.OnConnectFailed
                 .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnConnectFailed)}"))
                 .AddTo(disposables);

--- a/Samples~/MVS/ClientControl/ClientControlPresenter.cs
+++ b/Samples~/MVS/ClientControl/ClientControlPresenter.cs
@@ -26,16 +26,16 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
                 .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnStarted)}"))
                 .AddTo(disposables);
 
-            peerClient.OnStartedFailed
-                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnStartedFailed)}"))
+            peerClient.OnStartFailed
+                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnStartFailed)}"))
                 .AddTo(disposables);
 
-            peerClient.OnConnectFailed
-                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnConnectFailed)}"))
+            peerClient.OnSignalingConnectFailed
+                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnSignalingConnectFailed)}"))
                 .AddTo(disposables);
 
-            peerClient.OnDisconnected
-                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnDisconnected)}"))
+            peerClient.OnSignalingDisconnected
+                .Subscribe(_ => appState.Notify($"Received: {nameof(PeerClient.OnSignalingDisconnected)}"))
                 .AddTo(disposables);
         }
     }

--- a/Samples~/MVS/ClientControl/ClientControlScope.cs
+++ b/Samples~/MVS/ClientControl/ClientControlScope.cs
@@ -12,7 +12,6 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
         {
             var peerConfig = new PeerConfig(
                 "http://127.0.0.1:3010",
-                15,
                 new SocketIOOptions
                 {
                     ConnectionTimeout = TimeSpan.FromSeconds(3),
@@ -25,8 +24,9 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
                     "stun:stun2.l.google.com:19302",
                     "stun:stun3.l.google.com:19302",
                     "stun:stun4.l.google.com:19302",
-                });
-
+                },
+                TimeSpan.FromSeconds(15)
+                );
             var peerClient = PeerClientProvider.Provide(peerConfig);
             builder.RegisterComponent(peerClient);
 

--- a/Samples~/MVS/ClientControl/ClientControlScope.cs
+++ b/Samples~/MVS/ClientControl/ClientControlScope.cs
@@ -11,7 +11,7 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
         protected override void Configure(IContainerBuilder builder)
         {
             var peerConfig = new PeerConfig(
-                "http://127.0.0.1:3010",
+                "https://signaling.extreal.net,
                 new SocketIOOptions
                 {
                     ConnectionTimeout = TimeSpan.FromSeconds(3),

--- a/Samples~/MVS/ClientControl/ClientControlScope.cs
+++ b/Samples~/MVS/ClientControl/ClientControlScope.cs
@@ -12,6 +12,7 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
         {
             var peerConfig = new PeerConfig(
                 "http://127.0.0.1:3010",
+                15,
                 new SocketIOOptions
                 {
                     ConnectionTimeout = TimeSpan.FromSeconds(3),

--- a/Samples~/MVS/ClientControl/ClientControlScope.cs
+++ b/Samples~/MVS/ClientControl/ClientControlScope.cs
@@ -11,7 +11,7 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
         protected override void Configure(IContainerBuilder builder)
         {
             var peerConfig = new PeerConfig(
-                "https://signaling.extreal.net,
+                "http://127.0.0.1:3010",
                 new SocketIOOptions
                 {
                     ConnectionTimeout = TimeSpan.FromSeconds(3),

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.p2p.webrtc",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -6,14 +6,12 @@ class ClientState {
     private readonly onStartedFailed: OnStartedFailed;
     private isIceCandidateGatheringFinished: boolean;
     private isOfferAnswerProcessFinished: boolean;
-    private isHostConnected: boolean;
 
     constructor(onStarted: OnStarted, onStartedFailed: OnStartedFailed) {
         this.onStarted = onStarted;
         this.onStartedFailed = onStartedFailed;
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
-        this.isHostConnected = false;
     }
 
     public finishIceCandidateGathering = () => {
@@ -26,25 +24,11 @@ class ClientState {
         this.fireOnStarted();
     };
 
-    public finishHostConnection = (isConnectionWithHost: boolean) => {
-        if (isConnectionWithHost) {
-            this.isHostConnected = true;
-            this.fireOnStarted();
-        } else {
-            this.isHostConnected = false;
-        }
-    };
-
     private fireOnStarted = () => {
         if (this.isIceCandidateGatheringFinished && this.isOfferAnswerProcessFinished) {
             this.onStarted();
         }
     };
-
-    public fireOnClientStarted = () => {
-        if (!this.isHostConnected) { return }
-        this.fireOnStarted ();
-    }
 
     public fireOnStartedFailed = () => {
             this.onStartedFailed();
@@ -53,7 +37,6 @@ class ClientState {
     public clear = () => {
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
-        this.isHostConnected = false;
     };
 }
 

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -1,12 +1,15 @@
 type OnStarted = () => void;
+type OnStartedFailed = () => void;
 
 class ClientState {
     private readonly onStarted: OnStarted;
+    private readonly onStartedFailed: OnStartedFailed;
     private isIceCandidateGatheringFinished: boolean;
     private isOfferAnswerProcessFinished: boolean;
 
-    constructor(onStarted: OnStarted) {
+    constructor(onStarted: OnStarted, onStartedFailed: OnStartedFailed) {
         this.onStarted = onStarted;
+        this.onStartedFailed = onStartedFailed;
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
     }
@@ -27,6 +30,10 @@ class ClientState {
         }
     };
 
+    public fireOnStartedFailed = () => {
+            this.onStartedFailed();
+    };
+
     public clear = () => {
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
@@ -34,4 +41,4 @@ class ClientState {
 }
 
 export type { OnStarted };
-export { ClientState };
+    export { ClientState, OnStartedFailed };

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -41,4 +41,4 @@ class ClientState {
 }
 
 export type { OnStarted };
-    export { ClientState, OnStartedFailed };
+export { ClientState, OnStartedFailed };

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -1,15 +1,15 @@
 type OnStarted = () => void;
-type OnStartedFailed = () => void;
+type OnStartFailed = () => void;
 
 class ClientState {
     private readonly onStarted: OnStarted;
-    private readonly onStartedFailed: OnStartedFailed;
+    private readonly onStartFailed: OnStartFailed;
     private isIceCandidateGatheringFinished: boolean;
     private isOfferAnswerProcessFinished: boolean;
 
-    constructor(onStarted: OnStarted, onStartedFailed: OnStartedFailed) {
+    constructor(onStarted: OnStarted, onStartFailed: OnStartFailed) {
         this.onStarted = onStarted;
-        this.onStartedFailed = onStartedFailed;
+        this.onStartFailed = onStartFailed;
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
     }
@@ -30,8 +30,8 @@ class ClientState {
         }
     };
 
-    public fireOnStartedFailed = () => {
-            this.onStartedFailed();
+    public fireOnStartFailed = () => {
+            this.onStartFailed();
     };
 
     public clear = () => {
@@ -41,4 +41,4 @@ class ClientState {
 }
 
 export type { OnStarted };
-export { ClientState, OnStartedFailed };
+export { ClientState, OnStartFailed };

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -6,12 +6,14 @@ class ClientState {
     private readonly onStartedFailed: OnStartedFailed;
     private isIceCandidateGatheringFinished: boolean;
     private isOfferAnswerProcessFinished: boolean;
+    private isHostConnected: boolean;
 
     constructor(onStarted: OnStarted, onStartedFailed: OnStartedFailed) {
         this.onStarted = onStarted;
         this.onStartedFailed = onStartedFailed;
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
+        this.isHostConnected = false;
     }
 
     public finishIceCandidateGathering = () => {
@@ -24,11 +26,24 @@ class ClientState {
         this.fireOnStarted();
     };
 
+    public finishHostConnection = (isConnectionWithHost: boolean) => {
+        if (isConnectionWithHost) {
+            this.isHostConnected = true;
+            this.fireOnStarted();
+        }
+        this.isHostConnected = false;
+    };
+
     private fireOnStarted = () => {
         if (this.isIceCandidateGatheringFinished && this.isOfferAnswerProcessFinished) {
             this.onStarted();
         }
     };
+
+    public fireOnClientStarted = () => {
+        if (!this.isHostConnected) { return }
+        this.fireOnStarted ();
+    }
 
     public fireOnStartedFailed = () => {
             this.onStartedFailed();
@@ -37,6 +52,7 @@ class ClientState {
     public clear = () => {
         this.isIceCandidateGatheringFinished = false;
         this.isOfferAnswerProcessFinished = false;
+        this.isHostConnected = false;
     };
 }
 

--- a/WebScripts~/src/ClientState.ts
+++ b/WebScripts~/src/ClientState.ts
@@ -30,8 +30,9 @@ class ClientState {
         if (isConnectionWithHost) {
             this.isHostConnected = true;
             this.fireOnStarted();
+        } else {
+            this.isHostConnected = false;
         }
-        this.isHostConnected = false;
     };
 
     private fireOnStarted = () => {

--- a/WebScripts~/src/PeerAdapter.ts
+++ b/WebScripts~/src/PeerAdapter.ts
@@ -20,9 +20,9 @@ class PeerAdapter {
             }
             this.peerClient = new PeerClient(peerConfig, {
                 onStarted: () => callback(this.withPrefix("HandleOnStarted")),
-                onStartedFailed: () => callback(this.withPrefix("HandleOnStartedFailed")),
-                onConnectFailed: (reason) => callback(this.withPrefix("HandleOnConnectFailed"), reason),
-                onDisconnected: (reason) => callback(this.withPrefix("HandleOnDisconnected"), reason),
+                onStartFailed: () => callback(this.withPrefix("HandleOnStartFailed")),
+                onSignalingConnectFailed: (reason) => callback(this.withPrefix("HandleOnConnectFailed"), reason),
+                onSignalingDisconnected: (reason) => callback(this.withPrefix("HandleOnSignalingDisconnected"), reason),
             });
         });
 

--- a/WebScripts~/src/PeerAdapter.ts
+++ b/WebScripts~/src/PeerAdapter.ts
@@ -20,6 +20,7 @@ class PeerAdapter {
             }
             this.peerClient = new PeerClient(peerConfig, {
                 onStarted: () => callback(this.withPrefix("HandleOnStarted")),
+                onStartedFailed: () => callback(this.withPrefix("HandleOnStartedFailed")),
                 onConnectFailed: (reason) => callback(this.withPrefix("HandleOnConnectFailed"), reason),
                 onDisconnected: (reason) => callback(this.withPrefix("HandleOnDisconnected"), reason),
             });

--- a/WebScripts~/src/PeerAdapter.ts
+++ b/WebScripts~/src/PeerAdapter.ts
@@ -21,7 +21,7 @@ class PeerAdapter {
             this.peerClient = new PeerClient(peerConfig, {
                 onStarted: () => callback(this.withPrefix("HandleOnStarted")),
                 onStartFailed: () => callback(this.withPrefix("HandleOnStartFailed")),
-                onSignalingConnectFailed: (reason) => callback(this.withPrefix("HandleOnConnectFailed"), reason),
+                onSignalingConnectFailed: (reason) => callback(this.withPrefix("HandleOnSignalingConnectFailed"), reason),
                 onSignalingDisconnected: (reason) => callback(this.withPrefix("HandleOnSignalingDisconnected"), reason),
             });
         });

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -294,6 +294,9 @@ class PeerClient {
                     break;
                 }
                 case "disconnected": {
+                    window.setTimeout(() => {
+                        console.log('ICE connection failed due to disconnection timeout');
+                      }, 5000);
                     if (this.role === PeerRole.Client) {
                         this.clientState.fireOnStartedFailed();
                     }

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -286,9 +286,12 @@ class PeerClient {
                 case "new":
                     break;
                 case "checking":{
-                    connectionTimeout = setTimeout(() => {
-                        this.closePc(id);
-                }, this.peerConfig.timeout);
+                    if (this.role === PeerRole.Client) {
+                        connectionTimeout = setTimeout(() => {
+                            this.clientState.fireOnStartFailed();
+                            this.closePc(id);
+                        }, this.peerConfig.timeout);
+                    }
                 break;
                 }
                 case "disconnected": {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -286,13 +286,11 @@ class PeerClient {
                 case "checking":
                     break;
                 case "connected":
-                    if (this.role === PeerRole.Client) { 
-                        this.clientState.finishHostConnection(this.hostId === id);
-                        this.clientState.fireOnClientStarted(); 
-                    }
                 case "completed": {
                     if (this.role === PeerRole.Client) {
                         this.clientState.finishIceCandidateGathering();
+                        this.clientState.finishHostConnection(this.hostId === id);
+                        this.clientState.fireOnClientStarted(); 
                     }
                     break;
                 }

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -281,7 +281,7 @@ class PeerClient {
             if (this.isDebug) {
                 console.log(`Receive ice connection change: state=${pc.iceConnectionState} id=${id}`);
             }
-            await this.waitUntilTimeOut(pc.iceConnectionState);
+            await this.waitUntilTimeOut(pc);
             switch (pc.iceConnectionState) {
                 case "new":
                 case "checking":
@@ -412,12 +412,11 @@ class PeerClient {
         }
     };
 
-    private async waitUntilTimeOut(iceConnectionState: RTCIceConnectionState) {
-        const isNotCheckingOrDisconnected = iceConnectionState !== "checking" && iceConnectionState !== "disconnected";
-        if (isNotCheckingOrDisconnected) {
-            return
-        }
-        await waitUntil(() => isNotCheckingOrDisconnected, this.negotiationCancel(), 300);
+    private async waitUntilTimeOut(pc: RTCPeerConnection) {
+        const isNotCheckingOrDisconnected = () => {
+            return pc.iceConnectionState !== "checking" && pc.iceConnectionState !== "disconnected";
+        };
+        await waitUntil(isNotCheckingOrDisconnected, this.negotiationCancel(), 300);
     }
 
     private negotiationCancel = (): (() => boolean) => {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -277,7 +277,7 @@ class PeerClient {
             this.sendIce(id, event.candidate);
         };
 
-        pc.oniceconnectionstatechange = async () => {
+        pc.oniceconnectionstatechange = () => {
             if (this.isDebug) {
                 console.log(`Receive ice connection change: state=${pc.iceConnectionState} id=${id}`);
             }

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -295,7 +295,6 @@ class PeerClient {
                     if (this.role === PeerRole.Client) {
                         this.clientState.finishIceCandidateGathering();
                     }
-                    break;
                 }
                 case "disconnected": {
                     if (this.role === PeerRole.Client) {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -282,7 +282,6 @@ class PeerClient {
             }
             switch (pc.iceConnectionState) {
                 case "new":
-                    break;
                 case "checking":
                     break;
                 case "connected":

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -285,7 +285,7 @@ class PeerClient {
             switch (pc.iceConnectionState) {
                 case "new":
                     break;
-                case "checking":{
+                case "checking": {
                     if (this.role === PeerRole.Client) {
                         connectionTimeout = setTimeout(() => {
                             this.clientState.fireOnStartFailed();

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -290,6 +290,10 @@ class PeerClient {
                     break;
                 }
                 case "connected":
+                    if (this.role === PeerRole.Client) { 
+                        this.clientState.finishHostConnection(this.hostId === id);
+                        this.clientState.fireOnClientStarted(); 
+                    }
                 case "completed": {
                     if (this.role === PeerRole.Client) {
                         this.clientState.finishIceCandidateGathering();

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -284,6 +284,15 @@ class PeerClient {
                 case "new":
                 case "checking":
                     break;
+                case "disconnected": {
+                    window.setTimeout(() => {
+                        console.log('ICE connection failed due to disconnection timeout');
+                        }, 5000);
+                    if (this.role === PeerRole.Client) {
+                        this.clientState.fireOnStartedFailed();
+                    }
+                    break;
+                }
                 case "connected":
                 case "completed": {
                     if (this.role === PeerRole.Client && this.hostId === id) {
@@ -291,15 +300,7 @@ class PeerClient {
                     }
                     break;
                 }
-                case "disconnected": {
-                    window.setTimeout(() => {
-                        console.log('ICE connection failed due to disconnection timeout');
-                      }, 5000);
-                    if (this.role === PeerRole.Client) {
-                        this.clientState.fireOnStartedFailed();
-                    }
-                    break;
-                }
+
                 case "failed":
                     if (this.role === PeerRole.Client) {
                         this.clientState.fireOnStartedFailed();

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -282,21 +282,24 @@ class PeerClient {
             }
             switch (pc.iceConnectionState) {
                 case "new":
-                case "checking":
-                case "disconnected": {
-                    if (this.role === PeerRole.Client) {
-                        this.clientState.fireOnStartedFailed();
-                    }
                     break;
-                }
+                case "checking":
+                    break;
                 case "connected":
                     if (this.role === PeerRole.Client) { 
                         this.clientState.finishHostConnection(this.hostId === id);
                         this.clientState.fireOnClientStarted(); 
                     }
+                    break
                 case "completed": {
                     if (this.role === PeerRole.Client) {
                         this.clientState.finishIceCandidateGathering();
+                    }
+                    break;
+                }
+                case "disconnected": {
+                    if (this.role === PeerRole.Client) {
+                        this.clientState.fireOnStartedFailed();
                     }
                     break;
                 }

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -285,7 +285,7 @@ class PeerClient {
             switch (pc.iceConnectionState) {
                 case "new":
                 case "checking": {
-                    if (this.role === PeerRole.Client) {
+                    if (!connectionTimeout && this.role === PeerRole.Client) {
                         connectionTimeout = setTimeout(() => {
                             this.clientState.fireOnStartFailed();
                             this.closePc(id);

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -287,7 +287,6 @@ class PeerClient {
                     break;
                 case "checking":{
                     connectionTimeout = setTimeout(() => {
-                        console.error('Connection Timeout');
                         this.closePc(id);
                 }, this.peerConfig.timeout);
                 break;
@@ -419,26 +418,6 @@ class PeerClient {
             this.logError(funcName, e);
         }
     };
-
-    private async waitUntilTimeOut(pc: RTCPeerConnection) {
-        const isNotCheckingOrDisconnected = () => {
-            return pc.iceConnectionState !== "checking" && pc.iceConnectionState !== "disconnected";
-        };
-        await waitUntil(isNotCheckingOrDisconnected, this.negotiationCancel(), 300);
-    }
-
-    private negotiationCancel = (): (() => boolean) => {
-        const startTime = Date.now();
-        return () => {
-            const elapsedTime = Date.now() - startTime;
-            const isTimeout = elapsedTime >= this.peerConfig.timeout * 1000;
-            if (isTimeout) {
-                this.clientState.fireOnStartFailed();
-            }
-            return isTimeout;
-        };
-    };
-    
       
     private logError = (funcName: string, e: unknown) => {
         if (this.isDebug) {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -284,7 +284,6 @@ class PeerClient {
             let connectionTimeout: ReturnType<typeof setTimeout> | undefined;
             switch (pc.iceConnectionState) {
                 case "new":
-                    break;
                 case "checking": {
                     if (this.role === PeerRole.Client) {
                         connectionTimeout = setTimeout(() => {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -423,10 +423,15 @@ class PeerClient {
     private negotiationCancel = (): (() => boolean) => {
         const startTime = Date.now();
         return () => {
-          const elapsedTime = Date.now() - startTime;
-          return elapsedTime >= this.peerConfig.negotiationTimeoutSeconds*1000;
+            const elapsedTime = Date.now() - startTime;
+            const isTimeout = elapsedTime >= this.peerConfig.negotiationTimeoutSeconds * 1000;
+            if (isTimeout) {
+                this.clientState.fireOnStartedFailed();
+            }
+            return isTimeout;
         };
     };
+    
       
     private logError = (funcName: string, e: unknown) => {
         if (this.isDebug) {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -285,14 +285,8 @@ class PeerClient {
             switch (pc.iceConnectionState) {
                 case "new":
                 case "checking":
-                    break;
                 case "disconnected": {
-                    window.setTimeout(() => {
-                        console.log('ICE connection failed due to disconnection timeout');
-                        }, 5000);
-                    if (this.role === PeerRole.Client) {
-                        this.clientState.fireOnStartedFailed();
-                    }
+                    // do nothing
                     break;
                 }
                 case "connected":
@@ -302,7 +296,6 @@ class PeerClient {
                     }
                     break;
                 }
-
                 case "failed":
                 case "closed": {
                     if (this.role === PeerRole.Client) {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -290,11 +290,11 @@ class PeerClient {
                         this.clientState.finishHostConnection(this.hostId === id);
                         this.clientState.fireOnClientStarted(); 
                     }
-                    break
                 case "completed": {
                     if (this.role === PeerRole.Client) {
                         this.clientState.finishIceCandidateGathering();
                     }
+                    break;
                 }
                 case "disconnected": {
                     if (this.role === PeerRole.Client) {

--- a/WebScripts~/src/PeerClient.ts
+++ b/WebScripts~/src/PeerClient.ts
@@ -286,10 +286,8 @@ class PeerClient {
                     break;
                 case "connected":
                 case "completed": {
-                    if (this.role === PeerRole.Client) {
+                    if (this.role === PeerRole.Client && this.hostId === id) {
                         this.clientState.finishIceCandidateGathering();
-                        this.clientState.finishHostConnection(this.hostId === id);
-                        this.clientState.fireOnClientStarted(); 
                     }
                     break;
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.integration.p2p.webrtc",
-  "version": "1.0.0-next.5",
+  "version": "1.0.0-next.6",
   "displayName": "Extreal.Integration.P2P.WebRTC",
   "unity": "2022.3",
   "author": {


### PR DESCRIPTION
# 何の変更を加えましたか？
PBI:https://github.com/orgs/extreal-dev/projects/1/views/1?pane=issue&itemId=40781432

- P2P接続の確立が一定時間以内に完了しないとタイムアウトで p2p start失敗を発火するようにした
  - p2pConfigからタイムアウト値を設定するようにした
  - タイムアウトは[iceConnectionState](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState)が"new"か"checking"から"connected"か"completed"となるまでの時間とした
- clientはhostと繋がった時のみ、p2p startするようにロジックを修正した
- p2p start失敗イベントを区分しやすいように、シグナリングサーバ接続失敗イベントの命名を修正した


- その他：
  - 既存タイムアウトの値について「ConnectionTimeout.Milliseconds」だと秒数が0になっていたため、「ConnectionTimeout.TotalMilliseconds」を使うように修正した 
    - 「https://socket.io/docs/v4/client-options/#timeout 」に渡すため

# 何を確認しましたか?

## 実装

- [ ] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [ ] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [ ] 静的解析で問題が見つからないことを確認しました
- [ ] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [ ] 全ての自動テストが成功することを確認しました
- [ ] テストカバレッジが100%になることを確認しました
- [ ] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

- [ ] GuideのReleaseページに変更内容が追加されることを確認しました
- [ ] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [ ] GuideのLearningページに変更が反映されることを確認しました
- [ ] Sample Applicationに変更が反映されることを確認しました

# レビュアーへのメッセージ
