### PR TITLE
シグナリングサーバーで使用するDockerイメージの更新

### DIFF
--- a/SignalingServer~/docker-compose.yaml
+++ b/SignalingServer~/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       retries: 5
 
   signaling:
-    image: denoland/deno:alpine-1.34.3
+    image: denoland/deno:alpine-1.39.4
     restart: always
     depends_on:
       - signaling-redis


### PR DESCRIPTION
# 何の変更を加えましたか？

- シグナリングサーバーで使用するDenoのDockerイメージのバージョン指定を更新しました。
  - この更新により、WebGLのみP2PでクライアントをStopすると`WebSocket connection to 'ws://...' failed: Close received after close`というWebSocketエラーが発生する問題が解消されます。
    - https://github.com/denoland/deno/issues/20948
    - https://github.com/denoland/deno/pull/20518
      - Denoのv1.38.0以降のバージョンに修正が取り込まれています。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
  - コードの修正がないため未確認 
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
  - コードの修正がないため未確認 
- [x] 静的解析で問題が見つからないことを確認しました
  - コードの修正がないため未確認 
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました
  - コードの修正がないため未確認 

## テスト

- [x] 全ての自動テストが成功することを確認しました
  - 自動テストがないため未確認 
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
  - 変更なし
- [x] GuideのLearningページに変更が反映されることを確認しました
  - 変更なし
- [x] Sample Applicationに変更が反映されることを確認しました
  - 変更なし

# レビュアーへのメッセージ

- [ガイドのPR](https://github.com/extreal-dev/Extreal.Guide/pull/61)

## 再現手順

- 事象確認
  - SignalingServer~/docker-compose.yamlのsignaling: image: を、denoland/deno:alpine-1.34.3にしてシグナリングサーバーを起動すると、Backボタンでグループ選択画面に戻った際にコンソールに`WebSocket connection to 'ws://...' failed: Close received after close`のエラーが出る
- 修正確認
  - SignalingServer~/docker-compose.yamlのsignaling: image: を、denoland/deno:alpine-1.39.4（1.38.0以降であれば可）にしてシグナリングサーバーを起動すると、Backボタンでグループ選択画面に戻った際にコンソールにエラーが出なくなる
