### PR TITLE
WebGLのスティッキーセッションへの対応

### DIFF
--- a/Runtime/PeerClientProvider.cs
+++ b/Runtime/PeerClientProvider.cs
@@ -21,7 +21,8 @@ namespace Extreal.Integration.P2P.WebRTC
 #if !UNITY_WEBGL || UNITY_EDITOR
             return new NativePeerClient(peerConfig);
 #else
-            return new WebGLPeerClient(new WebGLPeerConfig(peerConfig));
+            var webGLPeerConfig = peerConfig as WebGLPeerConfig ?? new WebGLPeerConfig(peerConfig);
+            return new WebGLPeerClient(webGLPeerConfig);
 #endif
         }
     }

--- a/Runtime/WebGLPeerClient.cs
+++ b/Runtime/WebGLPeerClient.cs
@@ -110,10 +110,12 @@ namespace Extreal.Integration.P2P.WebRTC
                     : Array.Empty<JsonRtcIceServer>()
             };
             var socketOptions = peerConfig.SocketOptions;
+            var webGLSocketOptions = peerConfig.WebGLSocketOptions;
             var jsonSocketOptions = new JsonSocketOptions
             {
                 ConnectionTimeout = (long)socketOptions.ConnectionTimeout.TotalMilliseconds,
                 Reconnection = socketOptions.Reconnection,
+                WithCredentials = webGLSocketOptions.WithCredentials,
             };
             var jsonPeerConfig = new JsonPeerConfig
             {
@@ -154,6 +156,9 @@ namespace Extreal.Integration.P2P.WebRTC
 
         [JsonPropertyName("reconnection")]
         public bool Reconnection { get; set; }
+
+        [JsonPropertyName("withCredentials")]
+        public bool WithCredentials { get; set; }
     }
 
     [SuppressMessage("Usage", "CC0047")]

--- a/Runtime/WebGLPeerConfig.cs
+++ b/Runtime/WebGLPeerConfig.cs
@@ -1,4 +1,5 @@
 ﻿#if UNITY_WEBGL
+using System.Diagnostics.CodeAnalysis;
 using Extreal.Core.Logging;
 
 namespace Extreal.Integration.P2P.WebRTC
@@ -7,13 +8,23 @@ namespace Extreal.Integration.P2P.WebRTC
     {
         private static readonly ELogger Logger = LoggingManager.GetLogger(nameof(WebGLPeerConfig));
 
-        public WebGLPeerConfig(PeerConfig peerConfig)
+        [SuppressMessage("Usage", "CC0057")]
+        public WebGLPeerConfig(PeerConfig peerConfig, WebGLSocketOptions webGLSocketOptions = null)
             : base(peerConfig.SignalingUrl, peerConfig.SocketOptions, peerConfig.IceServerConfigs,
                 peerConfig.P2PTimeout, peerConfig.VanillaIceTimeout)
-        {
-        }
+        => WebGLSocketOptions = webGLSocketOptions ?? new WebGLSocketOptions();
 
         public bool IsDebug => Logger.IsDebug();
+
+        public WebGLSocketOptions WebGLSocketOptions { get; }
+    }
+
+    public class WebGLSocketOptions
+    {
+        public bool WithCredentials { get; }
+
+        [SuppressMessage("Usage", "CC0057")]
+        public WebGLSocketOptions(bool withCredentials = false) => WithCredentials = withCredentials;
     }
 }
 #endif

--- a/Samples~/MVS/ClientControl/ClientControlScope.cs
+++ b/Samples~/MVS/ClientControl/ClientControlScope.cs
@@ -28,6 +28,13 @@ namespace Extreal.Integration.P2P.WebRTC.MVS.ClientControl
                         "stun:stun4.l.google.com:19302"
                     }, "test-name", "test-credential")
                 });
+#if UNITY_WEBGL && !UNITY_EDITOR
+            peerConfig = new WebGLPeerConfig(
+                peerConfig,
+                new WebGLSocketOptions(
+                    withCredentials: false
+                ));
+#endif
 
             var peerClient = PeerClientProvider.Provide(peerConfig);
             builder.RegisterComponent(peerClient);

--- a/SignalingServer~/docker-compose.yaml
+++ b/SignalingServer~/docker-compose.yaml
@@ -23,6 +23,8 @@ services:
       SIGNALING_LOGGING: ${SIGNALING_LOGGING:-on}
       # In production, change it to suit the environment.
       SIGNALING_CORS_ORIGIN: ${SIGNALING_CORS_ORIGIN:-*}
+      # In production, change it to suit the environment.
+      SIGNALING_CORS_CREDENTIALS: ${SIGNALING_CORS_CREDENTIALS:-false}
     ports:
       - 3010:3000
     working_dir: /app

--- a/SignalingServer~/index.ts
+++ b/SignalingServer~/index.ts
@@ -37,6 +37,7 @@ const log = (logMessage: () => string | object) => {
 
 const corsConfig = {
     origin: Deno.env.get("SIGNALING_CORS_ORIGIN"),
+    credentials: Deno.env.get("SIGNALING_CORS_CREDENTIALS") === "true",
 };
 
 const [pubClient, subClient] = await Promise.all([


### PR DESCRIPTION
# 何の変更を加えましたか？

- WebGLでスティッキーセッションを使用するための設定をコンフィグで行えるように変更しました。
  - WebGLPeerConfigでwithCredentialsオプションを受け取れるように変更しました。
  - シグナリングサーバー側でスティッキーセッション有効時に使用する環境変数を追加しました。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
  -  自動テストがないため未確認
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
  - 変更なし
- [x] Sample Applicationに変更が反映されることを確認しました
  - 変更なし

# レビュアーへのメッセージ

参考ページ
- [Using multiple nodes#Enabling sticky-session](https://socket.io/docs/v4/using-multiple-nodes/#enabling-sticky-session)
- [Handling CORS](https://socket.io/docs/v4/handling-cors/)

ガイドのPR
- [P2P.WebRTCのWebGLのスティッキーセッション有効化方法のガイド追記](https://github.com/extreal-dev/Extreal.Guide/pull/62)